### PR TITLE
Add ClassDeletion & ObjectPropertyDeletion

### DIFF
--- a/src/kgcl_schema/datamodel/kgcl.py
+++ b/src/kgcl_schema/datamodel/kgcl.py
@@ -273,6 +273,11 @@ class ObjectPropertyCreationId(NodeCreationId):
 class NodeDeletionId(NodeChangeId):
     pass
 
+class ClassDeletionId(NodeDeletionId):
+    pass
+
+class ObjectPropertyDeletionId(NodeDeletionId):
+    pass
 
 class NodeDirectMergeId(NodeObsoletionId):
     pass
@@ -2252,6 +2257,61 @@ class NodeDeletion(NodeChange):
 
         super().__post_init__(**kwargs)
 
+@dataclass
+class ClassDeletion(NodeDeletion):
+    """
+    A node deletion where the owl type is 'owl:Class'
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = KGCL.ClassDeletion
+    class_class_curie: ClassVar[str] = "kgcl:ClassDeletion"
+    class_name: ClassVar[str] = "ClassDeletion"
+    class_model_uri: ClassVar[URIRef] = KGCL.ClassDeletion
+
+    id: Union[str, ClassDeletionId] = None
+    superclass: Optional[Union[str, NodeId]] = None
+    change_description: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ClassDeletionId):
+            self.id = ClassDeletionId(self.id)
+
+        if self.superclass is not None and not isinstance(self.superclass, NodeId):
+            self.superclass = NodeId(self.superclass)
+
+        if self.change_description is not None and not isinstance(self.change_description, str):
+            self.change_description = str(self.change_description)
+
+        super().__post_init__(**kwargs)
+
+@dataclass
+class ObjectPropertyDeletion(NodeDeletion):
+    """
+    A node deletion where the owl type is 'ObjectProperty'
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = KGCL.ObjectPropertyDeletion
+    class_class_curie: ClassVar[str] = "kgcl:ObjectPropertyDeletion"
+    class_name: ClassVar[str] = "ObjectPropertyDeletion"
+    class_model_uri: ClassVar[URIRef] = KGCL.ObjectPropertyDeletion
+
+    id: Union[str, ObjectPropertyDeletionId] = None
+    change_description: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ObjectPropertyCreationId):
+            self.id = ObjectPropertyDeletionId(self.id)
+
+        if self.change_description is not None and not isinstance(self.change_description, str):
+            self.change_description = str(self.change_description)
+
+        super().__post_init__(**kwargs)
 
 @dataclass
 class NodeDirectMerge(NodeObsoletion):

--- a/src/kgcl_schema/schema/kgcl.yaml
+++ b/src/kgcl_schema/schema/kgcl.yaml
@@ -694,6 +694,20 @@ classes:
     slot_usage:
       change_description:
         string_serialization: delete {about_node}
+  ClassDeletion:
+    is_a: NodeDeletion
+    description: A node deletion where the owl type is 'owl:Class'
+    slots:
+    - superclass
+    slot_usage:
+      change_description:
+        string_serialization: delete class {about_node}
+  ObjectPropertyDeletion:
+    is_a: NodeDeletion
+    description: A node deletion where the owl type is 'ObjectProperty'
+    slot_usage:
+      change_description:
+        string_serialization: delete object property {about_node}
   NodeDirectMerge:
     is_a: NodeObsoletion
     mixins:


### PR DESCRIPTION
Add required datatype but not implemented: 
  - ClassDeletion: A node deletion where the owl type is 'owl:Class'. (Symmetrical extension for ClassCreation)
  - ObjectPropertyDeletion: A node deletion where the owl type is 'ObjectProperty'. (Symmetrical extension for ObjectPropertyCreation)

Update for related class references:
  - ClassDeletionId
  - ObjectPropertyDeletionId